### PR TITLE
1836jr updates

### DIFF
--- a/src/data/games/public/1836jr-30.json
+++ b/src/data/games/public/1836jr-30.json
@@ -50,6 +50,17 @@
       40,
       100,
       100
+    ],
+    "three-cost": [
+      "Free (+ hex)",
+      40,
+      100
+    ],
+    "four-cost": [
+      "Free (+ hex)",
+      40,
+      100,
+      100
     ]
   },
   "shareTypes": {
@@ -78,7 +89,7 @@
       "name": "Grande Compagnie du Luxembourg",
       "abbrev": "GCL",
       "color": "green",
-      "tokens": "four"
+      "tokens": "four-cost"
     },
     {
       "name": "Chemin de Fer du Nord",
@@ -90,7 +101,7 @@
       "name": "Noord-Brabantsch-Duitsche Spoorweg-Maatschappij",
       "abbrev": "NBDS",
       "color": "yellow",
-      "tokens": "three"
+      "tokens": "three-cost"
     },
     {
       "name": "Hollandsche IJzeren Spoorweg Maatschappij",

--- a/src/data/games/public/1836jr-30.json
+++ b/src/data/games/public/1836jr-30.json
@@ -69,7 +69,7 @@
   },
   "companies": [
     {
-      "name": "Chemins de Fer de L'Etat Belge",
+      "name": "Chemins de Fer de L'État Belge",
       "abbrev": "B",
       "color": "black",
       "tokens": "four"

--- a/src/data/games/public/1836jr-30.json
+++ b/src/data/games/public/1836jr-30.json
@@ -193,40 +193,51 @@
   ],
   "privates": [
     {
-      "name": "Amsterdam Canal Company - ACC",
+      "name": "Amsterdam Canal Company",
+      "id": "ACC",
       "price": 20,
       "revenue": 5,
-      "description": "Blocks Hex D6."
+      "description": "No special ability. Blocks hex D6 while owned by player."
     },
     {
-      "name": "Enkhuizen-Stavoren Ferry - E-SF",
+      "name": "Enkhuizen-Stavoren Ferry",
+      "id": "E-SF",
       "price": 40,
       "revenue": 10,
-      "description": "Company may place free tile on B8."
+      "hex": "B8",
+      "description": "Owning corporation may place a free tile on the E-SF hex B8 (the IJsselmeer Causeway) free of cost, in addition to its own tile placement. Blocks hex B8 while owned by player."
     },
     {
-      "name": "Charbonnages du Hainaut - CdH",
+      "name": "Charbonnages du Hainaut",
+      "id": "CdH",
       "price": 70,
       "revenue": 15,
-      "description": "Blocks Hex J8. Company may place tile and token on Hex J8 for F60."
+      "hex": "J8",
+      "description": "Owning corporation may place a tile and station token in the CdH hex J8 for only the F60 cost of the mountain. The track is not required to be connected to existing track of this corporation (or any corporation), and can be used as a teleport. This counts as the corporation's track lay for that turn. Blocks hex J8 while owned by player."
     },
     {
-      "name": "Grand Central Belge - GCB",
+      "name": "Grand Central Belge",
+      "id": "GCB",
       "price": 110,
       "revenue": 20,
-      "description": "Blocks Hex G7, G9 and H10. Owner may exchange for a share of the Etat Belge (this closes the private company)."
+      "company": "B",
+      "description": "Owning player may exchange the GCB for a 10% certificate of the Chemins de Fer de L’Etat Belge (B) from the bank or the bank pool, subject to normal certificate limits. This closes the private company. The exchange may be made a) in a stock round, during the player’s turn or between the turns of other players, or b) in an operating round, between the turns of corporations. Blocks hexes G7, G9, & H10 while owned by player."
     },
     {
-      "name": "Chemins de Fer Luxembourgeois - CFL",
+      "name": "Chemins de Fer Luxembourgeois",
+      "id": "CFL",
       "price": 160,
       "revenue": 25,
-      "description": "Blocks Hexes K11 & J12. Player gets a 10% certificate for GCL."
+      "company": "GCL",
+      "description": "Upon purchase, the owning player receives a 10% certificate of the Grande Compagnie du Luxembourg (GCL). This certificate may only be sold once the GCL President’s Certificate has been purchased and a par price set, subject to standard rules. Blocks hexes K11 & J12 while owned by player."
     },
     {
-      "name": "Chemin de Fer de Lille à Valenciennes - CFLV",
+      "name": "Chemin de Fer de Lille à Valenciennes",
+      "id": "CFLV",
       "price": 220,
       "revenue": 30,
-      "description": "Blocks Hexes I3 & J4. Includes president's certificate for the Chemin de Fer du Nord. Closes on first train purchase."
+      "company": "Nord",
+      "description": "Upon purchase, the owning player receives the President’s Certificate of the Chemin de Fer du Nord (Nord) and must immediately set the par price. This private company may not be bought by a corporation, and closes when the Nord buys its first train. Blocks hexes I3 & J4 while owned by player."
     }
   ],
   "phases": [

--- a/src/data/games/public/1836jr-56.json
+++ b/src/data/games/public/1836jr-56.json
@@ -51,6 +51,17 @@
       40,
       100,
       100
+    ],
+    "three-cost": [
+      "Free (+ hex)",
+      40,
+      100
+    ],
+    "four-cost": [
+      "Free (+ hex)",
+      40,
+      100,
+      100
     ]
   },
   "shareTypes": {
@@ -79,7 +90,7 @@
       "name": "Grande Compagnie du Luxembourg",
       "abbrev": "GCL",
       "color": "green",
-      "tokens": "four"
+      "tokens": "four-cost"
     },
     {
       "name": "Chemin de Fer du Nord",
@@ -91,7 +102,7 @@
       "name": "Noord-Brabantsch-Duitsche Spoorweg-Maatschappij",
       "abbrev": "NBDS",
       "color": "yellow",
-      "tokens": "three"
+      "tokens": "three-cost"
     },
     {
       "name": "Hollandsche IJzeren Spoorweg Maatschappij",

--- a/src/data/games/public/1836jr-56.json
+++ b/src/data/games/public/1836jr-56.json
@@ -218,28 +218,35 @@
   ],
   "privates": [
     {
-      "name": "Amsterdam Canal Company - ACC",
+      "name": "Amsterdam Canal Company",
+      "id": "ACC",
       "price": 20,
       "revenue": 5,
-      "description": "Blocks Hex D6."
+      "description": "No special ability. Blocks hex D6 while owned by player."
     },
     {
-      "name": "Enkhuizen-Stavoren Ferry - E-SF",
+      "name": "Enkhuizen-Stavoren Ferry",
+      "id": "E-SF",
       "price": 40,
       "revenue": 10,
-      "description": "Company may place free tile on B8."
+      "hex": "B8",
+      "description": "Owning corporation may place a free tile on the E-SF hex B8 (the IJsselmeer Causeway) free of cost, in addition to its own tile placement. Blocks hex B8 while owned by player."
     },
     {
-      "name": "Charbonnages du Hainaut - CdH",
+      "name": "Charbonnages du Hainaut",
+      "id": "CdH",
       "price": 50,
       "revenue": 10,
-      "description": "Blocks Hex J8. Company may place tile and token on Hex J8 for F60."
+      "hex": "J8",
+      "description": "Owning corporation may place a tile and station token in the CdH hex J8 for only the F60 cost of the mountain. Blocks hex J8 while owned by player."
     },
     {
-      "name": "Régie des Postes",
+      "name": "Régie des Postes",
+      "id": "RdP",
       "price": 70,
       "revenue": 15,
-      "description": "Owning company may place a +20 token on any city or town."
+      "token": { "label": "+20" },
+      "description": "Owning corporation may place the +20 token on any city or town. The value of that location is increased by F20 for each and every time that corporation’s trains visit it. Once placed, the token cannot be moved."
     }
   ],
   "phases": [

--- a/src/data/games/public/1836jr-56.json
+++ b/src/data/games/public/1836jr-56.json
@@ -247,6 +247,14 @@
       "revenue": 15,
       "token": { "label": "+20" },
       "description": "Owning corporation may place the +20 token on any city or town. The value of that location is increased by F20 for each and every time that corporation’s trains visit it. Once placed, the token cannot be moved."
+    },
+    {
+      "name": "Régie des Postes",
+      "id": "RdP",
+      "price": 70,
+      "revenue": 15,
+      "token": { "label": "+20" },
+      "description": "At any time during its operating round, the owning corporation may place the +20 token on any city or town. The value of that location is increased by F20 for each and every time that corporation’s trains visit it. Once placed, the token cannot be moved. Placing the token closes this private company. The token is removed with the purchase of the first 6 Train."
     }
   ],
   "phases": [

--- a/src/data/games/public/1836jr-56.json
+++ b/src/data/games/public/1836jr-56.json
@@ -70,7 +70,7 @@
   },
   "companies": [
     {
-      "name": "Chemins de Fer de L'Etat Belge",
+      "name": "Chemins de Fer de L'État Belge",
       "abbrev": "B",
       "color": "black",
       "tokens": "four"
@@ -278,7 +278,7 @@
   ],
   "pools": [
     {
-      "name": "Market",
+      "name": "Bank Pool",
       "notes": [
         {
           "color": "orange",


### PR DESCRIPTION
A few minor corrections for 1836jr:

- Correctly accent company name
- Add notes about home station hex cost to applicable charters
- Update the privates with more details and icons
- Add alternative text for one of the 1856 variant privates; rules are unclear how it should exactly behave. I hope it will be obvious to users to only use one of these privates (they are named the same).