### PR TITLE
Align private text to prevent wrapping with icons are present.

### DIFF
--- a/src/cards/private.scss
+++ b/src/cards/private.scss
@@ -94,7 +94,7 @@
 .private__icon,
 .private__company {
   float: left;
-  padding: 0 1em 1em 0;
+  padding: 0 1em 7em 0;
   width: 0.3in;
   height: 0.3in;
 


### PR DESCRIPTION
A small change that aligns the text of private companies to prevent wrapping when icons are displayed.

Before:
<img width="581" alt="Screen Shot 2020-04-08 at 16 31 46" src="https://user-images.githubusercontent.com/414204/78745507-74476200-79b8-11ea-85b2-b2bae354089a.png">

After:
<img width="590" alt="Screen Shot 2020-04-08 at 16 42 44" src="https://user-images.githubusercontent.com/414204/78745519-7b6e7000-79b8-11ea-82a2-e56a84b5b542.png">
