### PR TITLE
expanding mediumCities options, plus a few small tweaks

### DIFF
--- a/src/Hex.jsx
+++ b/src/Hex.jsx
@@ -147,7 +147,7 @@ const HexTile = ({ hex, id, mask, border, transparent, map }) => {
   );
   let mediumCityBorders = (
     <Position data={hex.mediumCities}>
-      {m => <MediumCity border={true} />}
+      {m => <MediumCity border={true} {...m} />}
     </Position>
   );
 

--- a/src/atoms/MediumCity.jsx
+++ b/src/atoms/MediumCity.jsx
@@ -3,12 +3,23 @@ import React from "react";
 import Color from "../data/Color";
 import Name from "./Name";
 
-const MediumCity = ({ border, name, reverse, color }) => {
+const MediumCity = ({ border, name, reverse, color, fillColor, fillOpacity, strokeColor, strokeWidth, width, strokeDashArray, outlineColor, outlineStroke, outlineStrokeWidth }) => {
+  fillColor = fillColor || color || "track";
+  strokeColor = strokeColor || "black";
+  strokeWidth = strokeWidth >= 0 ? strokeWidth : "1";
+  strokeDashArray = strokeDashArray || "";
+  fillOpacity = fillOpacity || "1";
+  outlineColor = outlineColor || "border";
+  outlineStroke = outlineStroke || "track";
+  outlineStrokeWidth = outlineStrokeWidth || "3";
+  let scale = width !== 0 ? width / 22 : 22;
   if (border) {
     return (
       <Color>
         {c => (
-          <circle fill={c("border")} stroke="none" cx="0" cy="0" r="21" />
+          <g transform={`scale(${scale})`}>
+            <circle fill={c("border")} stroke="none" cx="0" cy="0" r="21" />
+          </g>
         )}
       </Color>
     );
@@ -27,17 +38,21 @@ const MediumCity = ({ border, name, reverse, color }) => {
     return (
       <Color context="companies">
         {c => (
-          <g>
+          <g transform={`scale(${scale})`}>
             <circle
-              fill={c("border")}
-              stroke={c("track")}
-              strokeWidth="3"
+              fill={c(outlineColor)}
+              stroke={c(outlineStroke)}
+              strokeWidth={outlineStrokeWidth}
               cx="0"
               cy="0"
               r="17"
             />
             <circle
-              fill={c(color || "track")}
+              fill={c(fillColor)}
+              fill-opacity={fillOpacity}
+              stroke={c(strokeColor)}
+              strokeWidth={strokeWidth}
+              stroke-dasharray={strokeDashArray}
               cx="0"
               cy="0"
               r="12"

--- a/src/atoms/OffBoardRevenue.jsx
+++ b/src/atoms/OffBoardRevenue.jsx
@@ -46,9 +46,9 @@ const makeNode = (x, y, reverse, revenue, size) => {
     </Color>,
     <Color context="map"
            key={`text-${value}`}>
-      {c => (
+      {(c,t) => (
         <text
-          fill={c(revenue.textColor) || c("black")}
+          fill={c(revenue.textColor) || t(c(revenue.color))}
           fontSize={size}
           dominantBaseline="central"
           textAnchor="middle"

--- a/src/atoms/index.jsx
+++ b/src/atoms/index.jsx
@@ -315,14 +315,27 @@ const atoms = [{
   examples: [
     {tunnels: [{cost:40}]},
     {bridges: [{cost:40}]},
-    {hexagons: [{cost:"80"}]},
-    {hexagons: [{cost:"threeve",width:44,fillColor:"yellow",strokeWidth:0}]},
-    {diamonds: [{cost:"+20"}]},
     {tunnelEntrances: [{percent:1}]},
     {tunnelEntrances: [{angle:120,percent:1,rotation:-60,color:"red"},
                        {angle:180,percent:1,color:"orange"},
                        {angle:240,percent:1,rotation:60,color:"yellow"}
                       ]}]
+},{
+  group: "Shapes",
+  examples: [
+    {diamonds: [{cost:"+20"}]},
+    {hexagons: [{cost:"80"}]},
+    {hexagons: [{cost:"threeve",width:44,fillColor:"yellow",strokeWidth:0}]},
+    {circles: [{}]},
+    {circles: [{fillColor:"white",width:32,strokeWidth:0},
+               {width:30,fillOpacity:"0",strokeDashArray:"7 7"},
+               {fillColor:"black",width:20}]
+    },
+    {circles: [{width:50,fillColor:"yellow"}],
+     tunnels: [{fillOpacity:0.9,angle:60,percent:0.6}],
+     bridges: [{angle:-60,percent:0.6}],
+     diamonds: [{fillColor:"black",fillOpacity:"0.5",angle:180,percent:0.6}]
+    }]
 },{
   group: "Route Bonuses",
   examples: [


### PR DESCRIPTION
- moving shapes to their own examples section and adding circles examples
- offBoardRevenues can do better for default text color
- adding properties from shapes to mediumCities (mostly to get width)
- missing property spread for mediumCityBorders