### PR TITLE
boomtowns version 2

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -111,6 +111,8 @@ const App = () => (
             <Color context="companies">
               {(c,t,s,p) => (
                 <React.Fragment>
+                  <path id="boomtownCityPath" d="M 0 26 A 26 26 0 0 1 0 -26 A 26 26 0 0 1 0 26" />
+                  <path id="boomtownCityPathReverse" d="M 0 -26 A 26 26 0 0 0 0 26 A 26 26 0 0 0 0 -26" />
                   <path id="cityPath" d="M 0 30 A 30 30 0 0 1 0 -30 A 30 30 0 0 1 0 30" />
                   <path id="cityPathReverse" d="M 0 -30 A 30 30 0 0 0 0 30 A 30 30 0 0 0 0 -30" />
                   <path id="city2Path" d="M 0 30 L -25 30 A 30 30 0 0 1 -25 -30 L 25 -30 A 30 30 0 0 1 25 30 L 0 30" />

--- a/src/atoms/Boomtown.jsx
+++ b/src/atoms/Boomtown.jsx
@@ -3,12 +3,10 @@ import Color from "../data/Color";
 
 import Name from "./Name";
 
-const Boomtown = ({ border, city, name, color, bgColor, width, strokeWidth }) => {
-  width = width || 25;
-  let centerTownWidth = width * 5 / 12;
-  let boomtownBorderWidth = (width + centerTownWidth) / 2;
+const Boomtown = ({ border, city, name, straightCityNames, color, bgColor, width, strokeWidth, strokeDashArray }) => {
+  let cityWidth = width || 25;
+  let centerTownWidth = cityWidth * 5 / 12;
   strokeWidth = strokeWidth || 2;
-  let strokeDashArray = "6 6";
   if (border) {
     return (
       <Color>
@@ -17,7 +15,7 @@ const Boomtown = ({ border, city, name, color, bgColor, width, strokeWidth }) =>
             fill={c("border")}
             stroke="none"
             cx="0" cy="0"
-            r={city ? width + 3 : centerTownWidth + 4 }
+            r={city ? cityWidth + 3 : centerTownWidth + 4 }
           />
         )}
       </Color>
@@ -26,15 +24,35 @@ const Boomtown = ({ border, city, name, color, bgColor, width, strokeWidth }) =>
     let nameNode = null;
 
     if (name) {
+      let path = straightCityNames ? null :
+        (city ? "cityPath" : "boomtownCityPath");
+      if (path && name.reverse) {
+        path = path + "Reverse";
+      }
+      let y = name.y || (name.reverse ? 7 : 0);
+      if (straightCityNames) {
+        y -= name.reverse ? -24 : 32;
+      }
       nameNode = (
         <Name
           bgColor={bgColor}
           {...name}
-          y={name.y || (name.reverse ? 28 : -28)}
-        />
-      );
+          y={y}
+          path={path}
+          doRotation={true}
+        />);
+//      nameNode code for centerTowns
+//      nameNode = (
+//        <Name
+//          bgColor={bgColor}
+//          {...name}
+//          y={name.y || (name.reverse ? 28 : -28)}
+//        />
+//      );
     }
+
     if (city) {
+      strokeDashArray = strokeDashArray || "4 4";
       return (
         <Color context="companies">
           {c => (
@@ -45,7 +63,7 @@ const Boomtown = ({ border, city, name, color, bgColor, width, strokeWidth }) =>
                   stroke="none"
                   cx="0"
                   cy="0"
-                  r={width}
+                  r={cityWidth}
                 />
               </g>
               <g key="city-otherthing">
@@ -55,23 +73,7 @@ const Boomtown = ({ border, city, name, color, bgColor, width, strokeWidth }) =>
                   strokeWidth={strokeWidth}
                   cx="0"
                   cy="0"
-                  r={width}
-                />
-              </g>
-              <g key="center-town-outline">
-                <circle
-                  fill={c("centerTown")}
-                  stroke="none"
-                  cx="0" cy="0"
-                  r={centerTownWidth + 2}
-                />
-              </g>
-              <g key="center-town-fill">
-                <circle
-                  fill={c(color || "centerTown")}
-                  stroke="none"
-                  cx="0" cy="0"
-                  r={centerTownWidth}
+                  r={cityWidth}
                 />
               </g>
               <g key="boomtown-outline">
@@ -81,7 +83,7 @@ const Boomtown = ({ border, city, name, color, bgColor, width, strokeWidth }) =>
                   strokeWidth={strokeWidth}
                   stroke-dasharray={strokeDashArray}
                   cx="0" cy="0"
-                  r={boomtownBorderWidth}
+                  r={centerTownWidth}
                 />
               </g>
               {nameNode}
@@ -90,6 +92,7 @@ const Boomtown = ({ border, city, name, color, bgColor, width, strokeWidth }) =>
         </Color>
       );
     } else {
+      strokeDashArray = strokeDashArray || "6 6";
       return (
         <Color context="companies">
           {c => (
@@ -117,7 +120,7 @@ const Boomtown = ({ border, city, name, color, bgColor, width, strokeWidth }) =>
                   strokeWidth={strokeWidth}
                   stroke-dasharray={strokeDashArray}
                   cx="0" cy="0"
-                  r={boomtownBorderWidth+4}
+                  r={cityWidth}
                 />
               </g>
               {nameNode}


### PR DESCRIPTION
changing boomtowns to either be
 - a centerTown with a dashed circle the size of a city
 - a city with a dashed circle the size of a centerTown
changing boomtowns to do curved city names like cities
adding a new path for boomtown centerTowns, as the normal distance looks
  too far away from the city

NOTE: These changes should be merged at the same time as the 18TraXX2020.json changes
I'll be pushing to 18xx-maker/games next, as they're interdependent.