### PR TITLE
github.com/kelsin/18xx => github.com/18xx-maker/18xx-maker

### DIFF
--- a/src/Config.jsx
+++ b/src/Config.jsx
@@ -229,7 +229,7 @@ const Config = ({config, setConfig, resetConfig}) => {
       <Input name="companySvgLogos" label="Company Logos"
              description="This lets you choose to use SVG logos (when available) for companies instead of only colors and text. The different settings are explained on the [logos doc](/docs/logos) page" />
       <Input name="overrideCompanies" label="Override Companies"
-             description="This lets you change the companies for a game to a set list that are defined in [the code](https://github.com/kelsin/18xx/tree/master/src/data/companies)" />
+             description="This lets you change the companies for a game to a set list that are defined in [the code](https://github.com/18xx-maker/18xx-maker/tree/master/src/data/companies)" />
       <h3>Maps</h3>
       <Input name="coords" label="Coordinate Type"
              description="This lets you choose where the coordinates appear on the map (if at all)."/>

--- a/src/Footer.jsx
+++ b/src/Footer.jsx
@@ -7,7 +7,7 @@ const Footer = () => {
       <a
         target="_blank"
         rel="noopener noreferrer"
-        href="https://github.com/kelsin/18xx"
+        href="https://github.com/18xx-maker/18xx-maker"
       >
         Github
       </a>. Items copyright to their respective creators and publishers. Only

--- a/src/Home.jsx
+++ b/src/Home.jsx
@@ -46,7 +46,7 @@ const Home = () => {
               <strong>Important:</strong> Please do not use this site to print games that you don't have a license to print. This tool is not meant to enable piracy. Please support our 18xx designers, developers and publishers.
             </p>
             <p className="note wip">
-              <strong>Note:</strong> Some games are still works in progress. Please submit any bugs found as <a href="https://github.com/kelsin/18xx/issues">issues on github</a>!
+              <strong>Note:</strong> Some games are still works in progress. Please submit any bugs found as <a href="https://github.com/18xx-maker/18xx-maker/issues">issues on github</a>!
             </p>
           </React.Fragment>
         )}
@@ -67,7 +67,7 @@ const Home = () => {
       <ul><li><NavLink to="/logos">Logos</NavLink></li></ul>
       <h2>Tiles</h2>
       <p>Tiles are defined separately from each game in (currently){" "}
-        <a href="https://github.com/kelsin/18xx/blob/master/src/data/tiles.js">one giant file</a>.
+        <a href="https://github.com/18xx-maker/18xx-maker/blob/master/src/data/tiles.js">one giant file</a>.
         Tiles are defined with the exactly the same format as map hexes. All available tile/hex elements are
         called atoms and examples of the json required for each is <NavLink to="/tiles/atoms">available</NavLink>.</p>
       <p>If you are just interested in printing games from this site, you don't need to worry about these tiles.

--- a/src/docs/logos.md
+++ b/src/docs/logos.md
@@ -56,7 +56,7 @@ relevant `color-stroke-main` as well (for example: `color-stroke-purple`).
 
 Name the logo based on the company abbreviation you want it to be for and drop
 it in the
-[/src/data/logos](https://github.com/kelsin/18xx/tree/master/src/data/logos)
+[/src/data/logos](https://github.com/18xx-maker/18xx-maker/tree/master/src/data/logos)
 folder. Once this is done you should **make sure you have a backup** and run:
 
 ```sh

--- a/src/docs/overrides.md
+++ b/src/docs/overrides.md
@@ -15,7 +15,7 @@ options as well!
 ## Examples
 
 You can check out the lists of currently [defined
-overrides](https://github.com/kelsin/18xx/tree/master/src/data/companies). To
+overrides](https://github.com/18xx-maker/18xx-maker/tree/master/src/data/companies). To
 create new ones just create the json and then add it to the `index.js` in that
 folder.
 

--- a/src/docs/schema.md
+++ b/src/docs/schema.md
@@ -13,7 +13,7 @@ package](https://www.npmjs.com/package/18xx-schemas) called
 * [game](/schemas/game.schema.json) - **WIP** - Schema to define a game file
 * [config](/schemas/config.schema.json) - Schema to define the `defaults.json`
   format to manage the [config
-  file](https://github.com/kelsin/18xx/blob/master/src/defaults.json) for this
+  file](https://github.com/18xx-maker/18xx-maker/blob/master/src/defaults.json) for this
   tool.
 * [theme](/schemas/theme.schema.json) - Schema to define a color theme file
   (maps or companies)


### PR DESCRIPTION
I stumbled upon some dead links on the frontpage. sed to the rescue.

There are still some references in src/docs/running.md:
```
56:image](https://hub.docker.com/r/kelsin/18xx) that includes all games. Run the
61:docker run -it --rm -p 80:80 --name 18xx kelsin/18xx
74:       kelsin/18xx:develop
```
All other references to "kelsin" are mail or support links.

https://github.com/18xx-maker/18xx-maker/blob/master/src/data/tiles.js linked in src/Home.jsx is dead.