### PR TITLE
Use iconColor to color an icon in a Private

### DIFF
--- a/src/cards/Private.jsx
+++ b/src/cards/Private.jsx
@@ -36,6 +36,7 @@ const Private = ({
   maxPlayers,
   description,
   icon,
+  iconColor,
   hex,
   tile,
   token,
@@ -120,7 +121,7 @@ const Private = ({
                            </div>}
                   {icon && <div className="private__icon">
                             <Svg viewBox="-15 -15 30 30">
-                              <Icon type={icon} />
+                              <Icon type={icon} color={iconColor} />
                             </Svg>
                           </div>}
                   {Array.isArray(description)


### PR DESCRIPTION
Didn't see a way to color icons in Privates, added iconColor, like in Tokens. I used this in 18C2C pull request for the mining company