### PR TITLE
the old default circle diameter was lost when making the circle

### DIFF
--- a/src/atoms/Value.jsx
+++ b/src/atoms/Value.jsx
@@ -13,12 +13,18 @@ const Value = ({ value, fontSize, fontWeight, fontFamily, color, textColor, shap
   const { config } = useContext(ConfigContext);
 
   let length = format(value, game, config.currency["value"]).length;
+  let ry_default = (fontSize == undefined);
 
   fontSize = multiDefaultTo(15, fontSize, game.info.valueFontSize);
   fontWeight = multiDefaultTo("bold", fontWeight, game.info.valueFontWeight);
   fontFamily = multiDefaultTo("sans-serif", fontFamily, game.info.valueFontFamily);
 
-  let ry = fontSize * 3 / 4;
+  let ry;
+  if (ry_default) {
+    ry = 14;
+  } else {
+    ry = fontSize * 3 / 4;
+  }
   let rx = length > 2 ? length * ry * 3 / 5 : ry;
   color = color || "white";
   textColor = textColor || "black";


### PR DESCRIPTION
diameter derived from the fontSize.  This restores the default, but
keeps the circle a tad tighter when the game defines a specific fontSize.
Eventually, allowing the circle size to be specified would be good,
but that's beyond the scope of fixing this bug.