### PR TITLE
ci: do not run tests again on main branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,6 @@
 env:
   NODE_VERSION: 22
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main


### PR DESCRIPTION
These tests already run as part of the merge queue, this will save some time in CI.
