### PR TITLE
ci: run test.yaml on main pushes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,9 @@
 env:
   PLAYWRIGHT_BROWSERS_PATH: browsers
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main


### PR DESCRIPTION
Since we have moved to pnpm and have a playwright
cache, this should be easier to manage
