### PR TITLE
fix: name of tile manifest on the top of the page

### DIFF
--- a/src/TileManifest.css
+++ b/src/TileManifest.css
@@ -1,13 +1,4 @@
 .TileManifest {
-  display: grid;
-  grid-auto-rows: 0.5in;
-  grid-auto-flow: row dense;
-  gap: 1px;
-  grid-template: "title title title title" 0.5in / repeat(
-      4,
-      calc((8in - 5px) / 4)
-    );
-  text-align: left;
   width: 768px;
   margin: 0 auto 0.5in;
   font-family: sans-serif;
@@ -15,10 +6,16 @@
 }
 
 .TileManifest--Title {
-  grid-area: title;
   line-height: 0.5in;
   font-size: 0.25in;
   text-align: center;
+}
+
+.TileManifest--Grid {
+  display: grid;
+  grid-auto-rows: 0.5in;
+  grid-auto-flow: row dense;
+  gap: 1px;
 }
 
 .TileManifest--Tile {

--- a/src/pages/games/TileManifest.jsx
+++ b/src/pages/games/TileManifest.jsx
@@ -81,9 +81,7 @@ const TileManifest = () => {
         <div className="TileManifest--Title">
           {game.info.title} Tile Manifest
         </div>
-        <div className="TileManifest--Grid">
-          {tileNodes}
-        </div>
+        <div className="TileManifest--Grid">{tileNodes}</div>
       </div>
     </ColorContext.Provider>
   );

--- a/src/pages/games/TileManifest.jsx
+++ b/src/pages/games/TileManifest.jsx
@@ -81,7 +81,9 @@ const TileManifest = () => {
         <div className="TileManifest--Title">
           {game.info.title} Tile Manifest
         </div>
-        {tileNodes}
+        <div className="TileManifest--Grid">
+          {tileNodes}
+        </div>
       </div>
     </ColorContext.Provider>
   );


### PR DESCRIPTION
Before:

![image](https://github.com/user-attachments/assets/52b3b900-a9d7-43f6-9e95-fb264a307e6b)

After:

![Screenshot from 2024-11-27 00-37-31](https://github.com/user-attachments/assets/f544a14c-86b2-41e6-a669-bca65e7ec774)
