### PR TITLE
chore(app): turn sandbox mode on

### DIFF
--- a/electron.vite.config.js
+++ b/electron.vite.config.js
@@ -14,6 +14,11 @@ export default defineConfig({
         entry: "./electron/main/index.js",
         format: "es",
       },
+      rollupOptions: {
+        output: {
+          format: "cjs",
+        },
+      },
     },
     plugins: [externalizeDepsPlugin()],
     resolve: {
@@ -27,15 +32,15 @@ export default defineConfig({
       outDir: "dist/preload",
       lib: {
         entry: "./electron/preload/preload.js",
-        format: "es",
+        format: "cjs",
+      },
+      rollupOptions: {
+        output: {
+          format: "cjs",
+        },
       },
     },
     plugins: [externalizeDepsPlugin()],
-    resolve: {
-      alias: {
-        "@": path.resolve(import.meta.dirname, "src"),
-      },
-    },
   },
   renderer: {
     assetsInclude: ["**/*.md"],

--- a/electron/main/window.js
+++ b/electron/main/window.js
@@ -9,7 +9,7 @@ import { isDev } from "./dev.js";
 import { setMenu } from "./menu.js";
 
 export const lastRoute = getLastRoute();
-export const rootUrl = `file://${join(__dirname, "../renderer/index.html")}`;
+export const rootUrl = `file://${join(import.meta.dirname, "../renderer/index.html")}`;
 export const startBaseUrl =
   isDev && process.env["ELECTRON_RENDERER_URL"]
     ? process.env["ELECTRON_RENDERER_URL"]
@@ -30,8 +30,7 @@ export const createWindow = () => {
   mainWindow = new BrowserWindow({
     show: false,
     webPreferences: {
-      preload: join(import.meta.dirname, "../preload/preload.mjs"),
-      sandbox: false,
+      preload: join(import.meta.dirname, "../preload/preload.cjs"),
     },
   });
   mainWindow.on("close", () =>
@@ -59,8 +58,7 @@ export const captureWindow = () => {
     enableLargerThanScreen: true,
     show: false,
     webPreferences: {
-      preload: join(import.meta.dirname, "../preload/preload.mjs"),
-      sandbox: false,
+      preload: join(import.meta.dirname, "../preload/preload.cjs"),
       transparent: true,
     },
   });

--- a/electron/preload/preload.js
+++ b/electron/preload/preload.js
@@ -1,7 +1,4 @@
-const { contextBridge, ipcRenderer } = require("electron/renderer");
-const { webUtils } = require("electron");
-
-ipcRenderer.setMaxListeners(50);
+const { contextBridge, ipcRenderer, webUtils } = require("electron/renderer");
 
 const api = {
   // PDF/PNG Exporting
@@ -71,15 +68,4 @@ const api = {
   off: () => ipcRenderer.removeAllListeners(),
 };
 
-// Use `contextBridge` APIs to expose Electron APIs to
-// renderer only if context isolation is enabled, otherwise
-// just add to the DOM global.
-if (process.contextIsolated) {
-  try {
-    contextBridge.exposeInMainWorld("api", api);
-  } catch (error) {
-    console.error(error);
-  }
-} else {
-  window.api = api;
-}
+contextBridge.exposeInMainWorld("api", api);

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "repository": "github:18xx-maker/18xx-maker",
   "license": "MIT",
   "private": true,
-  "main": "./dist/main/index.js",
+  "main": "./dist/main/index.cjs",
   "bin": {
     "18xx-schemas": "bin/schemas.cjs"
   },


### PR DESCRIPTION
This means that we have better security in electron. The main and
preload scripts now render to common JS files and the windows created by
electron are now all sandboxed. The main process is still written as ESM
but the renderer is not since it's one require line isn't a real require
line anyway so there really is no difference.
