### PR TITLE
fix: allow charters with no trains and non-https contexts to work

### DIFF
--- a/src/components/Paginate.jsx
+++ b/src/components/Paginate.jsx
@@ -1,3 +1,5 @@
+import { useId } from "react";
+
 import { map } from "ramda";
 
 import Page from "@/components/Page";
@@ -7,7 +9,7 @@ import { addPaginationData, unitsToCss } from "@/util";
 
 const Paginate = ({ component, data, config, game, children }) => {
   // Generate an ID to use for svg content
-  const contentId = crypto.randomUUID();
+  const contentId = useId();
 
   const defs = <g id={contentId}>{children}</g>;
 

--- a/src/components/Phase.jsx
+++ b/src/components/Phase.jsx
@@ -85,7 +85,7 @@ const Phase = ({ phases, trains, minor, company }) => {
   let includeName = include("name", phases, minor, company);
   let includePhase = include("phase", phases, minor, company);
   let includeTrain =
-    trains.length > 0 && include("train", phases, minor, company);
+    trains && trains.length > 0 && include("train", phases, minor, company);
   let includeTiles = include("tiles", phases, minor, company);
   let includeLimit = include("limit", phases, minor, company);
   let includeNotes = include("notes", phases, minor, company);

--- a/src/components/atoms/Name.jsx
+++ b/src/components/atoms/Name.jsx
@@ -1,3 +1,5 @@
+import { useId } from "react";
+
 import { defaultTo } from "ramda";
 
 import Color from "@/components/Color";
@@ -6,6 +8,7 @@ import { useGame } from "@/hooks";
 import { getFontProps, multiDefaultTo } from "@/util";
 
 const Name = (props) => {
+  const id = useId();
   const game = useGame();
   let {
     name,
@@ -36,7 +39,6 @@ const Name = (props) => {
   let nameNode;
 
   if (path) {
-    let id = crypto.randomUUID();
     nameNode = (
       <>
         <defs>

--- a/src/components/tokens/Token.jsx
+++ b/src/components/tokens/Token.jsx
@@ -1,3 +1,5 @@
+import { useId } from "react";
+
 import { defaultTo } from "ramda";
 
 import Color from "@/components/Color";
@@ -81,6 +83,8 @@ const Token = ({
 
   tokenShape, // main token shape - square or anything else is circle
 }) => {
+  const clipId = useId();
+
   // Set a default width (smaller for destination tokens)
   width = width || (destination ? 15 : 25);
 
@@ -112,7 +116,6 @@ const Token = ({
     tokClip = <circle cx="0" cy="0" r={width + (bleed ? 5 : 0)} />;
   }
   // Create a clipping object for this token
-  let clipId = crypto.randomUUID();
   let clip = <clipPath id={clipId}>{tokClip}</clipPath>;
   let shapeMult = 1;
   let scaling = width / 25;


### PR DESCRIPTION
Fixes #665 