### PR TITLE
fix(game): match params slug with decoded meta slug

### DIFF
--- a/src/components/pages/games/Game.jsx
+++ b/src/components/pages/games/Game.jsx
@@ -20,7 +20,7 @@ const Game = () => {
   const navigate = useNavigate();
 
   useEffect(() => {
-    if (!game || match.params.slug !== game.meta.slug) {
+    if (!game || match.params.slug !== decodeURIComponent(game.meta.slug)) {
       dispatch(loadGame(match.params.slug))
         .then(addRecent)
         .catch(() => navigate("/games/"));


### PR DESCRIPTION
Fix matching params with encoded game meta slug.

[discord issue](https://discord.com/channels/1302895372749770752/1302897137004052490/1313471879503282186)
[discord fix](https://discord.com/channels/1302895372749770752/1302897137004052490/1316021288413696001)